### PR TITLE
Configurable timeouts for pending teleport requests

### DIFF
--- a/src/main/java/de/svdragster/teleportrequest/RequestCommands.java
+++ b/src/main/java/de/svdragster/teleportrequest/RequestCommands.java
@@ -1,7 +1,6 @@
 package de.svdragster.teleportrequest;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 
 import net.canarymod.Canary;
 import net.canarymod.api.entity.living.humanoid.Player;
@@ -11,130 +10,51 @@ import net.canarymod.commandsys.Command;
 import net.canarymod.commandsys.CommandListener;
 
 public class RequestCommands implements CommandListener {
+	
+	private TeleportRequest tpr;
+	
+	public RequestCommands(TeleportRequest tpr) {
+		this.tpr = tpr;
+	}
 
-	private static HashMap<Player, Player> requests = new HashMap<Player, Player>(); // Sender & Receiver of request
-	
-	public void newRequest(Player sender, Player receiver)  {
-		if (sender.equals(receiver)) {
-			sender.notice("How about no");
-		} else if (requests.containsKey(sender) && requests.get(sender).equals(receiver)) {
-			removeRequest(sender);
-			sender.notice("Cancelled request to " + receiver.getName());
-		} else {
-			requests.put(sender, receiver);
-			receiver.message(ChatFormat.GREEN + "You've received a teleportation request from " + ChatFormat.GOLD + sender.getName() + ChatFormat.GREEN + "!");
-			receiver.message(ChatFormat.YELLOW + "Type /tpaccept to teleport " + sender.getName() + " to you.");
-			sender.message(ChatFormat.GREEN + "Teleportation Request sent to " + ChatFormat.GOLD + receiver.getName() + ChatFormat.GREEN + ".");
-		}
-	}
-	
-	public void removeRequest(Player player) {
-		if (requests.containsKey(player)) {
-			requests.remove(player);
-		}
-		if (requests.containsValue(player)) {
-			for (Player sender : requests.keySet()) {
-				Player receiver = requests.get(sender);
-				if (receiver.equals(player)) {
-					requests.remove(sender);
-					sender.notice("Cancelled request to " + receiver.getName());
-				}
-			}
-		}
-	}
-	
-	public void accept(Player receiver, Player sender) {
-		if (sender == null) {
-			for (Player tempSender : requests.keySet()) {
-				if (requests.get(tempSender).equals(receiver)) {
-					tempSender.teleportTo(receiver.getLocation());
-					tempSender.message(ChatFormat.GREEN + receiver.getName() + " has accepted your teleportation request.");
-					receiver.message(ChatFormat.GREEN + tempSender.getName() + " has been teleported to you.");
-					removeRequest(tempSender);
-					return;
-				}
-			}
-			receiver.notice("No requests.");
-		} else {
-			if (requests.containsKey(sender)) {
-				if (requests.get(sender).equals(receiver)) {
-					sender.teleportTo(receiver.getLocation());
-					sender.message(ChatFormat.GREEN + receiver.getName() + " has accepted your teleportation request.");
-					receiver.message(ChatFormat.GREEN + sender.getName() + " has been teleported to you.");
-					removeRequest(sender);
-				} else {
-					receiver.notice("No request by " + sender.getName());
-				}
-			} else {
-				receiver.notice("No request by " + sender.getName());
-			}
-		}
-	}
-	
-	public void deny(Player receiver, Player sender) {
-		if (sender == null) {
-			for (Player tempSender : requests.keySet()) {
-				if (requests.get(tempSender).equals(receiver)) {
-					tempSender.notice(receiver.getName() + " has denied your teleportation request.");
-					receiver.notice("Denied request of " + tempSender.getName() + ".");
-					removeRequest(tempSender);
-					return;
-				}
-			}
-			receiver.notice("No requests.");
-		} else {
-			if (requests.containsKey(sender)) {
-				if (requests.get(sender).equals(receiver)) {
-					sender.notice(receiver.getName() + " has denied your teleportation request.");
-					receiver.notice("Denied request of " + sender.getName() + ".");
-					removeRequest(sender);
-				} else {
-					receiver.notice("No request by " + sender.getName());
-				}
-			} else {
-				receiver.notice("No request by " + sender.getName());
-			}
-		}
-	}
-	
-	public ArrayList<Player> getAllRequests(Player receiver) {
-		ArrayList<Player> senders = new ArrayList<Player>();
-		for (Player sender : requests.keySet()) {
-			if (requests.get(sender).equals(receiver)) {
-				senders.add(sender);
-			}
-		}
-		return senders;
-	}
-	
-	@Command(aliases = { "tpa" }, description = "Request to teleport to a player", permissions = { "request.request" }, toolTip = "/tpa <playername>")
+	@Command(
+			aliases = { "tpa", "call" },
+			description = "Request to teleport to a player",
+			permissions = { "request.request" },
+			toolTip = "/tpa <playername> or /call <playername>"
+	)
 	public void TpaCommand(MessageReceiver caller, String[] parameters) {
 		if (parameters.length >= 2) {
 			Player sender = Canary.getServer().getPlayer(caller.getName());
 			Player receiver = Canary.getServer().getPlayer(parameters[1]);
 			if (receiver != null) {
-				newRequest(sender, receiver);
+				tpr.newRequest(sender, receiver);
 			} else {
 				sender.notice(parameters[1] + " is not online.");
 			}
 		} else {
-			caller.notice("Usage: /tpa <playername>");
+			caller.notice("Usage: /tpa <playername> or /call <playername>");
 		}
 	}
 	
-	@Command(aliases = { "tpdeny" }, description = "Deny a pending teleport request to you", permissions = { "request.deny" }, toolTip = "/tpdeny [playername]")
+	@Command(
+			aliases = { "tpdeny" },
+			description = "Deny a pending teleport request to you",
+			permissions = { "request.deny" },
+			toolTip = "/tpdeny [playername]"
+	)
 	public void TpdenyCommand(MessageReceiver caller, String[] parameters) {
 		Player player = Canary.getServer().getPlayer(caller.getName());
-		ArrayList<Player> allRequests = getAllRequests(player);
-		if (allRequests.size() < 0) {
+		ArrayList<Player> allRequests = tpr.getAllRequests(player);
+		if (allRequests.size() <= 0) {
 			player.notice("No pending requests.");
 		} else if (allRequests.size() == 1) {
-			deny(player, null);
+			tpr.deny(player, null);
 		} else {
 			if (parameters.length >= 2) {
 				Player sender = Canary.getServer().getPlayer(parameters[1]);
 				if (sender != null) {
-					deny(player, sender);
+					tpr.deny(player, sender);
 				} else {
 					player.notice(parameters[1] + " is not online.");
 				}
@@ -155,19 +75,24 @@ public class RequestCommands implements CommandListener {
 		}
 	}
 	
-	@Command(aliases = { "tpaccept" }, description = "Accept a pending teleport request to you", permissions = { "request.accept" }, toolTip = "/tpaccept [playername]")
+	@Command(
+			aliases = { "tpaccept" },
+			description = "Accept a pending teleport request to you",
+			permissions = { "request.accept" },
+			toolTip = "/tpaccept [playername]"
+	)
 	public void TpacceptCommand(MessageReceiver caller, String[] parameters) {
 		Player player = Canary.getServer().getPlayer(caller.getName());
-		ArrayList<Player> allRequests = getAllRequests(player);
-		if (allRequests.size() < 0) {
+		ArrayList<Player> allRequests = tpr.getAllRequests(player);
+		if (allRequests.size() <= 0) {
 			player.notice("No pending requests.");
 		} else if (allRequests.size() == 1) {
-			accept(player, null);
+			tpr.accept(player, null);
 		} else {
 			if (parameters.length >= 3) {
 				Player sender = Canary.getServer().getPlayer(parameters[2]);
 				if (sender != null) {
-					accept(player, sender);
+					tpr.accept(player, sender);
 				} else {
 					player.notice(parameters[2] + " is not online.");
 				}

--- a/src/main/java/de/svdragster/teleportrequest/RequestConfiguration.java
+++ b/src/main/java/de/svdragster/teleportrequest/RequestConfiguration.java
@@ -1,0 +1,27 @@
+package de.svdragster.teleportrequest;
+
+import net.canarymod.config.Configuration;
+import net.canarymod.plugin.Plugin;
+import net.visualillusionsent.utils.PropertiesFile;
+
+public class RequestConfiguration {
+	private PropertiesFile cfg;
+	
+	public RequestConfiguration(Plugin p) {
+		cfg = Configuration.getPluginConfig(p);
+		
+		// check/set config with default values and relevant comments
+		if(!cfg.containsKey("timeout-enabled")) {
+			cfg.setBoolean("timeout-enabled", false, "Enable to timeout pending requests after a delay");
+		}
+		if(!cfg.containsKey("timeout")) {
+			cfg.setInt("timeout", 120, "Teleport request timeout in seconds");
+		}
+		cfg.save(); // save any keys that were generated
+	}
+
+
+	// reload-safe accessors for configuration file
+	public boolean isTimeoutEnabled(){ return cfg.getBoolean("timeout-enabled"); }
+	public int getTimeout(){ return cfg.getInt("timeout"); }
+}

--- a/src/main/java/de/svdragster/teleportrequest/RequestListener.java
+++ b/src/main/java/de/svdragster/teleportrequest/RequestListener.java
@@ -5,10 +5,15 @@ import net.canarymod.hook.player.DisconnectionHook;
 import net.canarymod.plugin.PluginListener;
 
 public class RequestListener implements PluginListener {
+	
+	private TeleportRequest tpr;
+	
+	public RequestListener(TeleportRequest tpr){
+		this.tpr = tpr;
+	}
 
 	@HookHandler
 	public void onLogout(DisconnectionHook hook) {
-		RequestCommands commands = new RequestCommands();
-		commands.removeRequest(hook.getPlayer());
+		tpr.removeRequest(hook.getPlayer());
 	}
 }

--- a/src/main/java/de/svdragster/teleportrequest/TeleportRequest.java
+++ b/src/main/java/de/svdragster/teleportrequest/TeleportRequest.java
@@ -1,24 +1,153 @@
 package de.svdragster.teleportrequest;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
 import net.canarymod.Canary;
+import net.canarymod.api.entity.living.humanoid.Player;
+import net.canarymod.chat.ChatFormat;
 import net.canarymod.commandsys.CommandDependencyException;
+import net.canarymod.logger.Logman;
 import net.canarymod.plugin.Plugin;
+import net.canarymod.tasks.ServerTaskManager;
 
 public class TeleportRequest extends Plugin {
+	
+	Logman logger;
+	RequestConfiguration config;
+	private HashMap<Player, Player> requests = new HashMap<Player, Player>(); // Sender & Receiver of request
+	private HashMap<Player, TimeoutTask> timers = new HashMap<Player, TimeoutTask>(); // timeouts for requests
+	
+	public TeleportRequest() {
+		logger = getLogman();
+		config = new RequestConfiguration(this);
+	}
 
 	public void disable() {
-
+		requests.clear();
+		timers.clear();
+		ServerTaskManager.removeTasks(this);
 	}
 
 	public boolean enable() {
-		Canary.hooks().registerListener(new RequestListener(), this);
+		Canary.hooks().registerListener(new RequestListener(this), this);
 		try {
-			Canary.commands().registerCommands(new RequestCommands(), this, false);
+			Canary.commands().registerCommands(new RequestCommands(this), this, false);
 		} catch (CommandDependencyException e) {
-			getLogman().error(e);
+			logger.error(e);
 			return false;
 		}
 		return true;
+	}
+	
+	public void newRequest(Player sender, Player receiver)  {
+		if (sender.equals(receiver)) {
+			sender.notice("You cannot request a teleport to yourself!");
+		} else
+			if (requests.containsKey(sender) && requests.get(sender).equals(receiver)) {
+			removeRequest(sender);
+			sender.notice("Cancelled request to " + receiver.getName());
+		} else {
+			requests.put(sender, receiver);
+			if(config.isTimeoutEnabled()){
+				TimeoutTask t = new TimeoutTask(this, sender);
+				timers.put(sender, t);
+				ServerTaskManager.addTask(t);
+			}
+			receiver.message(ChatFormat.GREEN + "You've received a teleportation request from " + ChatFormat.GOLD + sender.getName() + ChatFormat.GREEN + "!");
+			if(config.isTimeoutEnabled()){
+				receiver.message(ChatFormat.GREEN + "Note this request will timeout in " + ChatFormat.GOLD + config.getTimeout() + ChatFormat.GREEN + " seconds.");
+			}
+			receiver.message(ChatFormat.YELLOW + "Type /tpaccept to teleport " + sender.getName() + " to you.");
+			sender.message(ChatFormat.GREEN + "Teleportation Request sent to " + ChatFormat.GOLD + receiver.getName() + ChatFormat.GREEN + ".");
+		}
+	}
+	
+	public void removeRequest(Player player) {
+		if (requests.containsKey(player)) {
+			requests.remove(player);
+		}
+		if (timers.containsKey(player)) {
+			ServerTaskManager.removeTask(timers.get(player));
+			timers.remove(player);
+		}
+		if (requests.containsValue(player)) {
+			for (Player sender : requests.keySet()) {
+				Player receiver = requests.get(sender);
+				if (receiver.equals(player)) {
+					requests.remove(sender);
+					if(timers.containsKey(sender)) {
+						ServerTaskManager.removeTask(timers.get(sender));
+						timers.remove(sender);
+					}
+					sender.notice("Cancelled request to " + receiver.getName());
+				}
+			}
+		}
+	}
+	
+	public void accept(Player receiver, Player sender) {
+		if (sender == null) {
+			for (Player tempSender : requests.keySet()) {
+				if (requests.get(tempSender).equals(receiver)) {
+					tempSender.teleportTo(receiver.getLocation());
+					tempSender.message(ChatFormat.GREEN + receiver.getName() + " has accepted your teleportation request.");
+					receiver.message(ChatFormat.GREEN + tempSender.getName() + " has been teleported to you.");
+					removeRequest(tempSender);
+					return;
+				}
+			}
+			receiver.notice("No requests.");
+		} else {
+			if (requests.containsKey(sender)) {
+				if (requests.get(sender).equals(receiver)) {
+					sender.teleportTo(receiver.getLocation());
+					sender.message(ChatFormat.GREEN + receiver.getName() + " has accepted your teleportation request.");
+					receiver.message(ChatFormat.GREEN + sender.getName() + " has been teleported to you.");
+					removeRequest(sender);
+				} else {
+					receiver.notice("No request by " + sender.getName());
+				}
+			} else {
+				receiver.notice("No request by " + sender.getName());
+			}
+		}
+	}
+	
+	public void deny(Player receiver, Player sender) {
+		if (sender == null) {
+			for (Player tempSender : requests.keySet()) {
+				if (requests.get(tempSender).equals(receiver)) {
+					tempSender.notice(receiver.getName() + " has denied your teleportation request.");
+					receiver.notice("Denied request of " + tempSender.getName() + ".");
+					removeRequest(tempSender);
+					return;
+				}
+			}
+			receiver.notice("No requests.");
+		} else {
+			if (requests.containsKey(sender)) {
+				if (requests.get(sender).equals(receiver)) {
+					sender.notice(receiver.getName() + " has denied your teleportation request.");
+					receiver.notice("Denied request of " + sender.getName() + ".");
+					removeRequest(sender);
+				} else {
+					receiver.notice("No request by " + sender.getName());
+				}
+			} else {
+				receiver.notice("No request by " + sender.getName());
+			}
+		}
+	}
+	
+	public ArrayList<Player> getAllRequests(Player receiver) {
+		ArrayList<Player> senders = new ArrayList<Player>();
+		for (Player sender : requests.keySet()) {
+			if (requests.get(sender).equals(receiver)) {
+				senders.add(sender);
+			}
+		}
+		return senders;
 	}
 
 }

--- a/src/main/java/de/svdragster/teleportrequest/TimeoutTask.java
+++ b/src/main/java/de/svdragster/teleportrequest/TimeoutTask.java
@@ -1,0 +1,21 @@
+package de.svdragster.teleportrequest;
+
+import net.canarymod.api.entity.living.humanoid.Player;
+import net.canarymod.tasks.ServerTask;
+
+class TimeoutTask extends ServerTask {
+
+	private TeleportRequest p;
+	private Player sender;
+	
+	public TimeoutTask(TeleportRequest p, Player sender) {
+		super(p, p.config.getTimeout() * 20); // convert seconds to ticks
+		this.p = p;
+		this.sender = sender;
+	}
+
+	public void run() {
+		p.removeRequest(sender);
+		sender.notice("Teleport request has timed out.");
+	}
+}


### PR DESCRIPTION
- Added configurable timeouts for teleport requests. Configuration values:
  - timeout: set to true to enable timeouts to expire after a delay
  - timeout-delay: the delay in seconds before a pending timeout request expires (estimated, actually ticks under hood)
- fixed "no pending teleport request" bug (was reporting multiple requests when none actually pending)
- general refactor to ease message passing
